### PR TITLE
Ignore endpoints for ingresses that don't have status.LoadBalancer.Ingress defined

### DIFF
--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -169,6 +169,11 @@ func (e *Endpoint) WithSetIdentifier(setIdentifier string) *Endpoint {
 	return e
 }
 
+// EndpointsHaveEmptyTargets checks if an endpoint has no targets
+func EndpointsHaveEmptyTargets(ingEndpoints []*Endpoint) bool {
+	return len(ingEndpoints) == 1 && len(ingEndpoints[0].Targets) == 0
+}
+
 // WithProviderSpecific attaches a key/value pair to the Endpoint and returns the Endpoint.
 // This can be used to pass additional data through the stages of ExternalDNS's Endpoint processing.
 // The assumption is that most of the time this will be provider specific metadata that doesn't

--- a/endpoint/endpoint_test.go
+++ b/endpoint/endpoint_test.go
@@ -76,3 +76,15 @@ func TestSameFailures(t *testing.T) {
 		}
 	}
 }
+
+func TestEndpointHasEmptyTargets(t *testing.T) {
+	e := NewEndpoint("example.org", "CNAME")
+	if !EndpointsHaveEmptyTargets([]*Endpoint{e}) {
+		t.Errorf("%#v should not have targets", e)
+	}
+
+	e2 := NewEndpoint("example.org", "CNAME", "foo.com")
+	if EndpointsHaveEmptyTargets([]*Endpoint{e2}) {
+		t.Errorf("%#v should have targets", e2)
+	}
+}

--- a/plan/plan.go
+++ b/plan/plan.go
@@ -146,6 +146,14 @@ func (p *Plan) Calculate() *Plan {
 
 	for _, topRow := range t.rows {
 		for _, row := range topRow {
+			// We ignore defined Endpoints with empty targets, as there seems to be
+			// intention for the DNS entry, but it is not known where to point them.
+			// This is the case when the status is missing from ingresses because a
+			// failure in the ingress controller.
+			if endpoint.EndpointsHaveEmptyTargets(row.candidates) {
+				continue
+			}
+
 			if row.current == nil { //dns name not taken
 				changes.Create = append(changes.Create, t.resolver.ResolveCreate(row.candidates))
 			}

--- a/source/ingress_test.go
+++ b/source/ingress_test.go
@@ -247,6 +247,18 @@ func testEndpointsFromIngress(t *testing.T) {
 			expected:               []*endpoint.Endpoint{},
 			ignoreIngressRulesSpec: true,
 		},
+		{
+			title: "endpoint with empty targets if no status information in ingress",
+			ingress: fakeIngress{
+				dnsnames: []string{"example.com"},
+			},
+			expected: []*endpoint.Endpoint{
+				{
+					DNSName: "example.com",
+					Targets: endpoint.Targets{},
+				},
+			},
+		},
 	} {
 		t.Run(ti.title, func(t *testing.T) {
 			realIngress := ti.ingress.Ingress()


### PR DESCRIPTION
<!--
    Please read https://github.com/kubernetes-sigs/external-dns#contributing before submitting
    your pull request. Please fill in each section below to help us better prioritize your pull request. Thanks!
-->

**Description**

<!-- Please provide a summary of the change here. -->
If there's a hostname defined but there's no target to point it to, external-dns should skip it instead of deleting it.
We have had a failing ingress controller that removed the status from the ingress object when it got OOMKilled. This resulted in external-dns deleting DNS entries even though the load balancer address was not changed.
<!-- Please link to all GitHub issue that this pull request implements(i.e. Fixes #123) -->
Fixes #2677

**Checklist**

- [ ] Unit tests updated
- [ ] End user documentation updated
